### PR TITLE
Scope openid

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If the id_token of the logged in user has not expired (["exp" claim](http://self
 ~~~cs
 var options = new Dictionary<string, string>
 {
-    { "scope", "openid profile" }, // default: passthrough i.e. same as previous time token was asked for
+    { "scope", "openid name email picture" }, // default: passthrough i.e. same as previous time token was asked for
 };
 
 auth0.RenewIdToken(options: options);

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ var user = await auth0.LoginAsync("my-db-connection", "username", "password");
 Optionally you can specify the `scope` parameter. There are two possible values for scope today:
 
 * __scope: "openid"__ _(default)_ - It will return, not only the `access_token`, but also an `id_token` which is a Json Web Token (JWT). The JWT will only contain the user id.
-* __scope: "openid profile"__ - If you want the entire user profile to be part of the `id_token`.
+* __scope: "openid profile"__ - If you want the entire user profile to be part of the `id_token` (not recommended). This can cause problems when sending or receiving tokens in URLs (e.g. when using response_type=token) and will likely create an unnecessarily large token. Keep in mind that JWTs are sent on every API request, so it is desirable to keep them as small as possible.
 * __scope: "openid {attr1} {attr2} {attrN}"__ - You can also define specific attributes with this syntax. For example: `scope: "openid name email picture"`.
 
 ### Renew id_token if not expired

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ You can obtain a delegation token specifying the ID of the target client (`targe
 ~~~cs
 var options = new Dictionary<string, string>
 {
-    { "scope", "openid profile" },		// default: openid
+    { "scope", "openid name email picture" },		// default: openid
 };
 
 var result = await auth0.GetDelegationToken(


### PR DESCRIPTION
Added further explanation on the scope=openid profile according to the documentation and changed the two appearances of scope=openid profile for scope=openid name email picture